### PR TITLE
add FAILURE_IMAGE_OPEN to PTDetector class

### DIFF
--- a/api/batch_processing/api_core/batch_service/pytorch_detector.py
+++ b/api/batch_processing/api_core/batch_service/pytorch_detector.py
@@ -36,6 +36,8 @@ print(f'Using PyTorch version {torch.__version__}')
 
 class PTDetector:
 
+    FAILURE_IMAGE_OPEN = 'Failure image access'
+
     IMAGE_SIZE = 1280  # image size used in training
     STRIDE = 64
 

--- a/api/batch_processing/api_core/batch_service/score_v5.py
+++ b/api/batch_processing/api_core/batch_service/score_v5.py
@@ -164,10 +164,9 @@ class BatchScorer:
                 image = self._download_image(image_id)
             except Exception as e:
                 print(f'score_v5.py BatchScorer, score_images, download_image exception: {e}')
-                failure_code = getattr(self.detector, 'FAILURE_IMAGE_OPEN', 'Failed to open image')
                 result = {
                     'file': image_id,
-                    'failure': failure_code
+                    'failure': self.detector.FAILURE_IMAGE_OPEN
                 }
             else:
                 result = self.detector.generate_detections_one_image(


### PR DESCRIPTION
Fixes the error `raise RuntimeError(f'score.py, main(), exception in score_images(): {e}')
RuntimeError: score.py, main(), exception in score_images(): 'PTDetector' object has no attribute 'FAILURE_IMAGE_OPEN'` on running  the job. Related to this [pr](https://github.com/zooniverse/CameraTraps/pull/20)